### PR TITLE
Ajoute AntlPhonenumber.fixed_line

### DIFF
--- a/lib/antl_phonenumber.ex
+++ b/lib/antl_phonenumber.ex
@@ -217,7 +217,11 @@ defmodule AntlPhonenumber do
 
   @spec fixed_or_voip_line?(binary, binary | nil) :: boolean
   def fixed_or_voip_line?(number, ref_iso_country_code),
-    do: match?({:ok, type} when type in @fixed_or_voip_line_types, get_type(number, ref_iso_country_code))
+    do:
+      match?(
+        {:ok, type} when type in @fixed_or_voip_line_types,
+        get_type(number, ref_iso_country_code)
+      )
 
   @doc """
   Returns the country code of the number.

--- a/lib/antl_phonenumber.ex
+++ b/lib/antl_phonenumber.ex
@@ -10,9 +10,7 @@ defmodule AntlPhonenumber do
   # @supported_formats ~w(e164 international national rfc3966)
   @google_supported_formats ~w(e164 national)
   @supported_types ~w(premium_rate toll_free mobile fixed_line shared_cost voip personal_number pager uan voicemail)a
-  # libphonenumber classifies some fixed lines (e.g. Israeli 07x numbers) as :voip,
-  # so both :fixed_line and :voip are considered fixed lines.
-  @fixed_line_types ~w(fixed_line voip)a
+  @fixed_or_voip_line_types ~w(fixed_line voip)a
   @missing_iso_country_code_error_message "Missing reference iso_country_code. Please specify the iso_country_code or provide a e164/plus_e164."
 
   @doc """
@@ -208,21 +206,18 @@ defmodule AntlPhonenumber do
   end
 
   @doc """
-  Returns whether the number is a fixed line.
-
-  libphonenumber classifies some fixed lines (e.g. Israeli 07x numbers) as :voip,
-  so both :fixed_line and :voip are considered fixed lines.
+  Returns true if the number's type is :fixed_line or :voip, false otherwise.
 
   Note that if the number is not formatted in plus_e164 nor in e164 format,
   a reference iso_country_code is required.
   """
-  @spec fixed_line?(binary) :: boolean
-  def fixed_line?(number),
-    do: match?({:ok, type} when type in @fixed_line_types, get_type(number))
+  @spec fixed_or_voip_line?(binary) :: boolean
+  def fixed_or_voip_line?(number),
+    do: match?({:ok, type} when type in @fixed_or_voip_line_types, get_type(number))
 
-  @spec fixed_line?(binary, binary | nil) :: boolean
-  def fixed_line?(number, ref_iso_country_code),
-    do: match?({:ok, type} when type in @fixed_line_types, get_type(number, ref_iso_country_code))
+  @spec fixed_or_voip_line?(binary, binary | nil) :: boolean
+  def fixed_or_voip_line?(number, ref_iso_country_code),
+    do: match?({:ok, type} when type in @fixed_or_voip_line_types, get_type(number, ref_iso_country_code))
 
   @doc """
   Returns the country code of the number.

--- a/lib/antl_phonenumber.ex
+++ b/lib/antl_phonenumber.ex
@@ -10,6 +10,9 @@ defmodule AntlPhonenumber do
   # @supported_formats ~w(e164 international national rfc3966)
   @google_supported_formats ~w(e164 national)
   @supported_types ~w(premium_rate toll_free mobile fixed_line shared_cost voip personal_number pager uan voicemail)a
+  # libphonenumber classifies some fixed lines (e.g. Israeli 07x numbers) as :voip,
+  # so both :fixed_line and :voip are considered fixed lines.
+  @fixed_line_types ~w(fixed_line voip)a
   @missing_iso_country_code_error_message "Missing reference iso_country_code. Please specify the iso_country_code or provide a e164/plus_e164."
 
   @doc """
@@ -203,6 +206,23 @@ defmodule AntlPhonenumber do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  @doc """
+  Returns whether the number is a fixed line.
+
+  libphonenumber classifies some fixed lines (e.g. Israeli 07x numbers) as :voip,
+  so both :fixed_line and :voip are considered fixed lines.
+
+  Note that if the number is not formatted in plus_e164 nor in e164 format,
+  a reference iso_country_code is required.
+  """
+  @spec fixed_line?(binary) :: boolean
+  def fixed_line?(number),
+    do: match?({:ok, type} when type in @fixed_line_types, get_type(number))
+
+  @spec fixed_line?(binary, binary | nil) :: boolean
+  def fixed_line?(number, ref_iso_country_code),
+    do: match?({:ok, type} when type in @fixed_line_types, get_type(number, ref_iso_country_code))
 
   @doc """
   Returns the country code of the number.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AntlPhonenumber.MixProject do
   use Mix.Project
 
-  @version "0.1.12"
+  @version "0.2.0"
   @url "https://github.com/annatel/antl_phonenumber"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AntlPhonenumber.MixProject do
   use Mix.Project
 
-  @version "0.1.11"
+  @version "0.1.12"
   @url "https://github.com/annatel/antl_phonenumber"
 
   def project do

--- a/test/antl_phone_number_test.exs
+++ b/test/antl_phone_number_test.exs
@@ -256,6 +256,23 @@ defmodule AntlPhonenumberTest do
     assert AntlPhonenumber.get_type(not_number(), "IL") == {:error, "parsing error"}
   end
 
+  test "fixed_line?/1" do
+    assert plus_e164("IL", :fixed_line) |> AntlPhonenumber.fixed_line?()
+    assert plus_e164("IL", :voip) |> AntlPhonenumber.fixed_line?()
+    refute plus_e164("IL", :mobile) |> AntlPhonenumber.fixed_line?()
+
+    assert e164("IL", :fixed_line) |> AntlPhonenumber.fixed_line?()
+    refute e164("IL", :mobile) |> AntlPhonenumber.fixed_line?()
+  end
+
+  test "fixed_line?/2" do
+    assert local_number("IL", :fixed_line) |> AntlPhonenumber.fixed_line?("IL")
+    assert local_number("IL", :voip) |> AntlPhonenumber.fixed_line?("IL")
+    refute local_number("IL", :mobile) |> AntlPhonenumber.fixed_line?("IL")
+
+    refute AntlPhonenumber.fixed_line?(not_number(), "IL")
+  end
+
   test "get_country_code!/1" do
     assert AntlPhonenumber.get_country_code!(plus_e164("IL")) == "972"
     assert AntlPhonenumber.get_country_code!(e164("IL")) == "972"

--- a/test/antl_phone_number_test.exs
+++ b/test/antl_phone_number_test.exs
@@ -256,21 +256,21 @@ defmodule AntlPhonenumberTest do
     assert AntlPhonenumber.get_type(not_number(), "IL") == {:error, "parsing error"}
   end
 
-  test "fixed_line?/1" do
-    assert plus_e164("IL", :fixed_line) |> AntlPhonenumber.fixed_line?()
-    assert plus_e164("IL", :voip) |> AntlPhonenumber.fixed_line?()
-    refute plus_e164("IL", :mobile) |> AntlPhonenumber.fixed_line?()
+  test "fixed_or_voip_line?/1" do
+    assert plus_e164("IL", :fixed_line) |> AntlPhonenumber.fixed_or_voip_line?()
+    assert plus_e164("IL", :voip) |> AntlPhonenumber.fixed_or_voip_line?()
+    refute plus_e164("IL", :mobile) |> AntlPhonenumber.fixed_or_voip_line?()
 
-    assert e164("IL", :fixed_line) |> AntlPhonenumber.fixed_line?()
-    refute e164("IL", :mobile) |> AntlPhonenumber.fixed_line?()
+    assert e164("IL", :fixed_line) |> AntlPhonenumber.fixed_or_voip_line?()
+    refute e164("IL", :mobile) |> AntlPhonenumber.fixed_or_voip_line?()
   end
 
-  test "fixed_line?/2" do
-    assert local_number("IL", :fixed_line) |> AntlPhonenumber.fixed_line?("IL")
-    assert local_number("IL", :voip) |> AntlPhonenumber.fixed_line?("IL")
-    refute local_number("IL", :mobile) |> AntlPhonenumber.fixed_line?("IL")
+  test "fixed_or_voip_line?/2" do
+    assert local_number("IL", :fixed_line) |> AntlPhonenumber.fixed_or_voip_line?("IL")
+    assert local_number("IL", :voip) |> AntlPhonenumber.fixed_or_voip_line?("IL")
+    refute local_number("IL", :mobile) |> AntlPhonenumber.fixed_or_voip_line?("IL")
 
-    refute AntlPhonenumber.fixed_line?(not_number(), "IL")
+    refute AntlPhonenumber.fixed_or_voip_line?(not_number(), "IL")
   end
 
   test "get_country_code!/1" do


### PR DESCRIPTION
Dans libphonenumber, un numéro fixe peut être classé :fixed_line OU :voip (ex. les 07x israéliens / +9727…). Les deux sont des lignes fixes. fixed_line? renvoie un booléen via match? sur @fixed_line_types [:fixed_line, :voip].

Bump 0.1.11 -> 0.1.12.